### PR TITLE
Add support for RHEL9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the source archive in git
+linux-gpib-code-*-trunk.zip

--- a/linux-gpib-remove-usb-autotools.patch
+++ b/linux-gpib-remove-usb-autotools.patch
@@ -1,17 +1,20 @@
---- old/linux-gpib-user/configure.ac	2018-04-10 21:52:59.000000000 -0400
-+++ new/linux-gpib-user/configure.ac	2018-06-15 15:52:33.471227689 -0400
-@@ -182,9 +182,6 @@
+diff -ru old/linux-gpib-user/configure.ac new/linux-gpib-user/configure.ac
+--- old/linux-gpib-user/configure.ac	2024-03-30 13:08:39.627074000 -0400
++++ new/linux-gpib-user/configure.ac	2024-04-11 18:58:51.516184548 -0400
+@@ -205,10 +205,6 @@
  	language/php/TESTS/Makefile \
  	language/python/Makefile \
  	language/tcl/Makefile \
 -	usb/Makefile \
 -	usb/ni_usb_gpib/Makefile \
 -	usb/agilent_82357a/Makefile \
- ]
- )
+-	usb/lpvo_usb_gpib/Makefile \
  
---- old/linux-gpib-user/Makefile.am	2018-04-14 17:56:27.000000000 -0400
-+++ new/linux-gpib-user/Makefile.am	2018-06-15 15:57:25.391976815 -0400
+ ])
+ AC_OUTPUT
+diff -ru old/linux-gpib-user/Makefile.am new/linux-gpib-user/Makefile.am
+--- old/linux-gpib-user/Makefile.am	2024-04-09 16:44:14.882622219 -0400
++++ new/linux-gpib-user/Makefile.am	2024-04-09 16:44:22.023622591 -0400
 @@ -7,7 +7,7 @@
  #   the Free Software Foundation; either version 2 of the License, or
  #   (at your option) any later version.

--- a/linux-gpib-user-language-guile.patch
+++ b/linux-gpib-user-language-guile.patch
@@ -1,0 +1,23 @@
+diff -u old/linux-gpib-user/language/guile/gpib.c new/linux-gpib-user/language/guile/gpib.c
+--- old/linux-gpib-user/language/guile/gpib.c	2003-07-02 15:16:33.000000000 -0400
++++ new/linux-gpib-user/language/guile/gpib.c	2024-04-11 20:02:14.776382698 -0400
+@@ -23,7 +23,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+ 
+-#include <guile/gh.h>
++#include <libguile.h>
+ #include <gpib/ib.h>
+ 
+ #include "gpib.h"
+diff -u old/linux-gpib-user/language/guile/Makefile.am new/linux-gpib-user/language/guile/Makefile.am
+--- old/linux-gpib-user/language/guile/Makefile.am	2006-05-21 22:14:43.000000000 -0400
++++ new/linux-gpib-user/language/guile/Makefile.am	2024-04-11 19:40:34.730314966 -0400
+@@ -15,6 +15,6 @@
+ 
+ libgpib_guile_la_SOURCES = gpib.c
+ 
+-libgpib_guile_la_CFLAGS = $(LIBGPIB_CFLAGS)
++libgpib_guile_la_CFLAGS = -I/usr/include/guile/3.0 -L/usr/lib64 $(LIBGPIB_CFLAGS)
+ libgpib_guile_la_LDFLAGS = -release $(VERSION) $(LIBGPIB_LDFLAGS)
+ 

--- a/modprobe.d-gpib.conf
+++ b/modprobe.d-gpib.conf
@@ -1,0 +1,3 @@
+alias char-major-160 gpib_common
+alias gpib0 tnt4882
+install tnt4882 PATH=/sbin:/usr/sbin:/usr/local/sbin:$PATH;modprobe --ignore-install tnt4882;gpib_config --minor 0


### PR DESCRIPTION
Work to allow build of package for RedHat Enterprise Linux 9 (EL9).

  - Build the kernel module with ```SRCDIR=/lib/modules/$(uname -r)/build M=$(pwd)``` (see: https://www.kernel.org/doc/html/latest/kbuild/modules.html#creating-a-kbuild-file-for-an-external-module )
  - Make python2 conditional on rhel < 9 (see: https://pagure.io/fedora-kde/SIG/issue/102)
  - Add `modprobe.d/gpib.conf` to update permissions and configure the board upon modprobe of gpib0 / tnt4882 driver
  - Update `language/guile` install target for `guile30` and `guile30-devel` packages found in EL9 (compat-guile18 is now deprecated)

Build condition logic may still need some work to allow for a universal spec across all recent Fedora and RHEL compatible EL releases. (No attempt made to test on Rocky or Alma Linux as of this date.)

DKMS on RHEL9 was tested as working OK: tested (dkms build, install, clean boot, udev trigger, modprobe and ibtest).